### PR TITLE
Add AGENTS.md for Cursor Cloud development environment

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,65 @@
+## Cursor Cloud specific instructions
+
+### Project overview
+
+UniversalDAQ (uDAQ) is a pure Python (>=3.11) data acquisition platform. No external services, databases, Docker, or web servers are required. All code lives under `ACTIVE/`.
+
+### Working directory
+
+All commands must be run from `/workspace/ACTIVE` (where `pyproject.toml` lives), not the repo root.
+
+### Installing dependencies
+
+```
+cd /workspace/ACTIVE
+pip install -e ".[dev]"
+```
+
+The `[dev]` extra installs pytest, ruff, mypy, and pre-commit. The `[ui]` extra adds PySide6/pyqtgraph (not needed in headless environments).
+
+### Running tests
+
+```
+python3 -m pytest tests/ -q
+```
+
+265 tests pass. 10 meta/governance tests fail due to pre-existing issues (cache artifacts in root, root-layer allowlist drift, etc.) — these are not caused by environment setup.
+
+### Linting
+
+```
+python3 -m ruff check src/ tests/ tools/
+python3 -m ruff format --check src/ tests/ tools/
+python3 -m mypy src/universaldaq/ --ignore-missing-imports
+```
+
+Pre-existing lint/type errors exist in the repo (518 ruff, 295 mypy). These are known.
+
+### CI quality gate
+
+```
+python3 -m tools.dev.run_local_gate --package-root .
+```
+
+This runs governance validators, shell smoke, ruff, ruff-format, mypy, and pytest sequentially. It will fail on the pre-existing lint issues when `--strict-dev-tools` is passed. Without that flag it skips missing tools gracefully.
+
+### Smoke tests
+
+```
+python3 -m tools.dev.run_shell_smoke --package-root .
+python3 -m tools.dev.run_labjack_u6_smoke --package-root .
+```
+
+Both run in simulated mode (no hardware needed).
+
+### Key gotcha: PATH for installed scripts
+
+After `pip install -e ".[dev]"`, console scripts (e.g. `pytest`, `ruff`, `mypy`) are placed in `~/.local/bin`. Ensure this is on `PATH`:
+
+```
+export PATH="$HOME/.local/bin:$PATH"
+```
+
+### Contributing
+
+See `ACTIVE/CONTRIBUTING.md` and `ACTIVE/README.md` for the contributor flow and PR expectations.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Added `AGENTS.md` with Cursor Cloud specific development instructions for future agents.

## What this includes
- Project overview and working directory notes
- Dependency installation commands (`pip install -e ".[dev]"` from `ACTIVE/`)
- Test, lint, and CI quality gate commands
- Key gotchas (PATH for installed scripts, pre-existing lint/type errors, meta test failures)
- References to existing contributing docs

## Verification
All core functionality verified:

- **265/275 pytest tests pass** (10 meta/governance failures are pre-existing)
- **Shell smoke test**: passes
- **LabJack U6 simulated smoke test**: passes
- **Sandbox mapping demo** (apply → diff → rollback): passes

Full verification log:
[dev_env_verification.log](https://cursor.com/agents/bc-3c567a81-3da6-4178-a687-f19756a82d60/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdev_env_verification.log)

## Checklist
- [x] No existing code modified
- [x] AGENTS.md created at repo root
- [x] Update script configured for VM startup

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3c567a81-3da6-4178-a687-f19756a82d60"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3c567a81-3da6-4178-a687-f19756a82d60"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

