### PR TITLE
Bump GitHub Actions checkout and setup-python to v6

### DIFF
--- a/ACTIVE/.github/workflows/ci.yml
+++ b/ACTIVE/.github/workflows/ci.yml
@@ -8,8 +8,8 @@ jobs:
   quality-gate:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.11'
       - name: Install project and dev dependencies
@@ -23,8 +23,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: quality-gate
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.11'
       - name: Install project and dev dependencies


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- What changed: Bumped `actions/checkout` and `actions/setup-python` from v4/v5 to v6 in `ACTIVE/.github/workflows/ci.yml`.
- Governing source(s): Dependabot PRs #1 and #2 (consolidated into one clean branch after main governance cleanup).

## Documentation impact map
- Affected modules: `ACTIVE/.github/workflows/ci.yml`
- Affected requirement IDs: none
- Affected invariant IDs: none
- Affected tests / proof outputs: CI workflow only
- Affected controlled docs: none
- Affected controlled READMEs: none
- Affected registries / snapshots: none
- Reviewed but intentionally unchanged docs: all governance docs
- Reviewed but intentionally unchanged READMEs: all
- Reviewed but intentionally deferred docs logged in `UDQ-GOV-REG-003`: none

## Checklist
- [x] CI workflow updated for both jobs (`quality-gate`, `simulated-u6-smoke`)
- [ ] Supersedes stale Dependabot PRs #1 and #2 (close manually after merge)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a9f5e79b-9436-40de-aa98-fc2b4ab1b58f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a9f5e79b-9436-40de-aa98-fc2b4ab1b58f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

