### PR TITLE
Add root CI workflow so GitHub Actions runs from ACTIVE/

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,39 @@
+name: ci
+
+on:
+  push:
+  pull_request:
+
+defaults:
+  run:
+    working-directory: ACTIVE
+
+jobs:
+  quality-gate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.11'
+      - name: Install project and dev dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e .[dev]
+      - name: Run local gate
+        run: python -m tools.dev.run_local_gate --package-root . --strict-dev-tools
+
+  simulated-u6-smoke:
+    runs-on: ubuntu-latest
+    needs: quality-gate
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.11'
+      - name: Install project and dev dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e .[dev]
+      - name: Run simulated LabJack U6 smoke path
+        run: python -m tools.dev.run_labjack_u6_smoke --package-root .


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- What changed: Added root `.github/workflows/ci.yml` so GitHub Actions actually runs CI for this repo.
- Why: Workflows under `ACTIVE/.github/workflows/` are not discovered by GitHub; only root `.github/workflows/` is used.

## Details
- Sets `defaults.run.working-directory: ACTIVE` so gate/smoke commands run in the package root.
- Uses `actions/checkout@v6` and `actions/setup-python@v6`.
- Mirrors the existing `ACTIVE/.github/workflows/ci.yml` job structure.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a9f5e79b-9436-40de-aa98-fc2b4ab1b58f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a9f5e79b-9436-40de-aa98-fc2b4ab1b58f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

